### PR TITLE
Fix argument parsing bugs

### DIFF
--- a/create-convex/README.md
+++ b/create-convex/README.md
@@ -13,7 +13,7 @@ via additional command line options. For example, to scaffold a Convex project
 with no client, run:
 
 ```bash
-npm create convex@latest my-app -- -t bare
+npm create convex@latest my-app -t bare
 ```
 
 `-t` is a shorthand for `--template`
@@ -33,14 +33,15 @@ You can use `.` for the project name to scaffold in the current directory:
 npm create convex@latest .
 ```
 
-You can use any repository on GitHub as a template by providing the owner and repo names:
+You can use any repository on GitHub as a template by providing the owner and
+repo names:
 
 ```sh
-npm create convex@latest my-app -- -t thomasballinger/convex-clerk-users-table
+npm create convex@latest my-app -t thomasballinger/convex-clerk-users-table
 ```
 
 optionally with a branch name:
 
 ```sh
-npm create convex@latest my-app -- -t 'thomasballinger/convex-clerk-users-table#branch'
+npm create convex@latest my-app -t 'thomasballinger/convex-clerk-users-table#branch'
 ```

--- a/create-convex/package-lock.json
+++ b/create-convex/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-convex",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-convex",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "degit": "^2.8.4"

--- a/create-convex/src/index.ts
+++ b/create-convex/src/index.ts
@@ -134,7 +134,11 @@ async function init() {
         },
         {
           type: (framework) => {
-            if (framework.name === "other") {
+            if (argTemplate) {
+              return null;
+            }
+
+            if (framework?.name === "other") {
               throw new Error(
                 red("✖") +
                   " Follow one of the quickstarts at " +
@@ -142,11 +146,7 @@ async function init() {
               );
             }
 
-            return argTemplate
-              ? null
-              : framework.name === "bare"
-              ? null
-              : "select";
+            return framework?.name === "bare" ? null : "select";
           },
           name: "auth",
           hint: "Use arrow-keys, <return> to confirm",


### PR DESCRIPTION
Fixes a couple of small bugs in the create-convex script related to argument parsing:

1. `--` causes `-t` template to be ignored (not parsed)
    - The README currently instructs folks to use
`--` between the app name and any flags, which
causes the args after `--` not to be parsed,
so the script does not recognize any template
specified with `-t` and instead forces the
user into the prompts unnecessarily.
    - This removes the `--` from the instructions,
so users will have their flagged args parsed
correctly.

1.  the script throws an error if specifying a non-default name (other than 'my-app') and a template 
    - Currently, if app name and template are specified
with `npm create convex app-name -- -t template-name`,
the command throws the error "Cannot read properties
of undefined (reading 'name')".
    - This fixes the error, which is thrown by the framework
arg type function, by checking for an argTemplate
or undefined framework value.

