### PR TITLE
ease up on unused variables

### DIFF
--- a/template-bare/.eslintrc.cjs
+++ b/template-bare/.eslintrc.cjs
@@ -16,6 +16,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 

--- a/template-nextjs-clerk-shadcn/.eslintrc.cjs
+++ b/template-nextjs-clerk-shadcn/.eslintrc.cjs
@@ -19,6 +19,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 

--- a/template-nextjs-lucia-shadcn/.eslintrc.cjs
+++ b/template-nextjs-lucia-shadcn/.eslintrc.cjs
@@ -19,6 +19,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 

--- a/template-nextjs-shadcn/.eslintrc.cjs
+++ b/template-nextjs-shadcn/.eslintrc.cjs
@@ -19,6 +19,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 

--- a/template-react-vite-clerk-shadcn/.eslintrc.cjs
+++ b/template-react-vite-clerk-shadcn/.eslintrc.cjs
@@ -30,6 +30,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 

--- a/template-react-vite-shadcn/.eslintrc.cjs
+++ b/template-react-vite-shadcn/.eslintrc.cjs
@@ -30,6 +30,12 @@ module.exports = {
     // TypeScript, and can be removed for stricter
     // linting down the line.
 
+    // Only warn on unused variables, and ignore variables starting with `_`
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+    ],
+
     // Allow escaping the compiler
     "@typescript-eslint/ban-ts-comment": "error",
 


### PR DESCRIPTION
Seeing errors on unused variables makes it hard to tell if you're using Convex correctly - when you make a new function, you see errors on ctx & args, and generally seems more distracting than need be. Warning seems like a good middle ground of being useful but not failing typecheck