### PR TITLE
Dev mode: importing from package still runs codegen

### DIFF
--- a/template-component/example/convex/convex.config.ts
+++ b/template-component/example/convex/convex.config.ts
@@ -1,5 +1,5 @@
 import { defineApp } from "convex/server";
-import component from "../../src/component/convex.config";
+import component from "@convex-dev/counter/convex.config.js";
 
 const app = defineApp();
 app.use(component, { name: "counter" });

--- a/template-component/example/convex/exercise.ts
+++ b/template-component/example/convex/exercise.ts
@@ -1,5 +1,5 @@
 import { internalMutation, components } from "./_generated/server.js";
-import { Client, defineCounter } from "../../src/client/index.js";
+import { Client, defineCounter } from "@convex-dev/counter";
 
 const counter = new Client(components.counter, { shards: { beans: 100 } });
 
@@ -7,7 +7,7 @@ const usersCounter = defineCounter(components.counter, "users", 100);
 
 export const usingClient = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     await counter.add(ctx, "accomplishments");
     await counter.add(ctx, "beans", 2);
     const count = await counter.count(ctx, "beans");
@@ -17,7 +17,7 @@ export const usingClient = internalMutation({
 
 export const usingFunctions = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     await usersCounter.inc(ctx);
     await usersCounter.inc(ctx);
     await usersCounter.dec(ctx);
@@ -27,7 +27,7 @@ export const usingFunctions = internalMutation({
 
 export const directCall = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     await ctx.runMutation(components.counter.public.add, {
       name: "pennies",
       count: 250,

--- a/template-component/example/convex/tsconfig.json
+++ b/template-component/example/convex/tsconfig.json
@@ -17,7 +17,13 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+
+    /* This should only be used in this example. Real apps should not attempt
+     * to compile TypeScript because differences between tsconfig.json files can
+     * cause the code to be compiled differently.
+     */
+    "customConditions": ["@convex-dev/component-source"]
   },
   "include": ["./**/*"],
   "exclude": ["./_generated"]

--- a/template-component/example/package-lock.json
+++ b/template-component/example/package-lock.json
@@ -8,7 +8,8 @@
       "name": "uses-component",
       "version": "0.0.0",
       "dependencies": {
-        "convex": "^1.15.1-alpha.2"
+        "@convex-dev/counter": "file:..",
+        "convex": "^1.16.0-alpha.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
@@ -19,6 +20,26 @@
         "globals": "^15.9.0",
         "typescript": "^5.5.0"
       }
+    },
+    "..": {
+      "name": "@convex-dev/counter",
+      "version": "0.0.0",
+      "dependencies": {
+        "convex": "^1.16.0-alpha.1"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.9.1",
+        "@types/node": "^18.17.0",
+        "eslint": "^9.9.1",
+        "globals": "^15.9.0",
+        "prettier": "3.2.5",
+        "typescript": "~5.0.3",
+        "typescript-eslint": "^8.4.0"
+      }
+    },
+    "node_modules/@convex-dev/counter": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.0",
@@ -883,9 +904,9 @@
       "dev": true
     },
     "node_modules/convex": {
-      "version": "1.15.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.15.1-alpha.2.tgz",
-      "integrity": "sha512-ldAizfJ9KmpOlSZPm0lR2eFs7es6V+ss5ghn2EsNRitONBRUdK0O3rUkXlVUY3dLUea12HsHV40kxQuizSzZsw==",
+      "version": "1.16.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.16.0-alpha.1.tgz",
+      "integrity": "sha512-z+ZdvMvjHsTW++4xJil1mvHXnDvKMxbLaB/4n4awzOMxalPJEEr+NpwX/Ie4ALbHi6yP7bxtd4IESaQuH0spkA==",
       "dependencies": {
         "esbuild": "0.23.0",
         "globals": "~15.9.0",
@@ -1886,6 +1907,19 @@
     }
   },
   "dependencies": {
+    "@convex-dev/counter": {
+      "version": "file:..",
+      "requires": {
+        "@eslint/js": "^9.9.1",
+        "@types/node": "^18.17.0",
+        "convex": "^1.16.0-alpha.1",
+        "eslint": "^9.9.1",
+        "globals": "^15.9.0",
+        "prettier": "3.2.5",
+        "typescript": "~5.0.3",
+        "typescript-eslint": "^8.4.0"
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
@@ -2356,9 +2390,9 @@
       "dev": true
     },
     "convex": {
-      "version": "1.15.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.15.1-alpha.2.tgz",
-      "integrity": "sha512-ldAizfJ9KmpOlSZPm0lR2eFs7es6V+ss5ghn2EsNRitONBRUdK0O3rUkXlVUY3dLUea12HsHV40kxQuizSzZsw==",
+      "version": "1.16.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.16.0-alpha.1.tgz",
+      "integrity": "sha512-z+ZdvMvjHsTW++4xJil1mvHXnDvKMxbLaB/4n4awzOMxalPJEEr+NpwX/Ie4ALbHi6yP7bxtd4IESaQuH0spkA==",
       "requires": {
         "esbuild": "0.23.0",
         "globals": "~15.9.0",

--- a/template-component/example/package.json
+++ b/template-component/example/package.json
@@ -3,12 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "dev": "convex dev",
+    "dev": "convex dev --live-component-sources",
     "logs": "convex logs",
     "lint": "tsc -p convex && eslint convex"
   },
   "dependencies": {
-    "convex": "^1.15.1-alpha.2"
+    "@convex-dev/counter": "file:..",
+    "convex": "^1.16.0-alpha.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",

--- a/template-component/package.json
+++ b/template-component/package.json
@@ -6,6 +6,7 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc --project ./esm.json && echo '{\\n  \"type\": \"module\"\\n}' > dist/esm/package.json",
     "build:cjs": "tsc --project ./commonjs.json && echo '{\\n  \"type\": \"commonjs\"\\n}' > dist/commonjs/package.json",
+    "dev": "cd example; npm run dev",
     "typecheck": "tsc --noEmit",
     "prepare": "npm run build",
     "prepack": "node node10stubs.mjs",
@@ -20,37 +21,38 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@convex-dev/component-source": "./src/client/index.ts",
         "types": "./dist/esm/client/index.d.ts",
         "default": "./dist/esm/client/index.js"
       },
       "require": {
+        "@convex-dev/component-source": "./src/client/index.ts",
         "types": "./dist/commonjs/client/index.d.ts",
         "default": "./dist/commonjs/client/index.js"
       }
     },
     "./frontend": {
       "import": {
+        "@convex-dev/component-source": "./src/frontend/index.ts",
         "types": "./dist/esm/frontend.d.ts",
         "default": "./dist/esm/frontend.js"
       },
       "require": {
+        "@convex-dev/component-source": "./src/frontend/index.ts",
         "types": "./dist/commonjs/frontend.d.ts",
         "default": "./dist/commonjs/frontend.js"
       }
     },
     "./convex.config.js": {
       "import": {
+        "@convex-dev/component-source": "./src/component/convex.config.ts",
         "types": "./dist/esm/component/convex.config.d.ts",
         "default": "./dist/esm/component/convex.config.js"
-      },
-      "require": {
-        "types": "./dist/commonjs/component/convex.config.d.ts",
-        "default": "./dist/commonjs/component/convex.config.js"
       }
     }
   },
   "dependencies": {
-    "convex": "1.15.1-alpha.2"
+    "convex": "^1.16.0-alpha.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/template-component/src/component/_generated/api.d.ts
+++ b/template-component/src/component/_generated/api.d.ts
@@ -28,7 +28,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   public: typeof public;
 }>;
-declare const fullApiWithMounts: typeof fullApi & {
+export type Mounts = {
   public: {
     add: FunctionReference<
       "mutation",
@@ -39,6 +39,10 @@ declare const fullApiWithMounts: typeof fullApi & {
     count: FunctionReference<"query", "public", { name: string }, number>;
   };
 };
+// For now fullApiWithMounts is only fullApi which provides
+// jump-to-definition in component client code.
+// Use Mounts for the same type without the inference.
+declare const fullApiWithMounts: typeof fullApi;
 
 export declare const api: FilterApi<
   typeof fullApiWithMounts,


### PR DESCRIPTION
Importing the component from the example using `"@convex-dev/counter": "file:..",` still runs codegen by using `convex dev --live-component-source`.