### PR TITLE
snip .js, and install counter without name, with named import

### DIFF
--- a/template-component/example/convex/convex.config.ts
+++ b/template-component/example/convex/convex.config.ts
@@ -1,5 +1,5 @@
 import { defineApp } from "convex/server";
-import counter from "@convex-dev/counter/convex.config.js";
+import counter from "@convex-dev/counter/convex.config";
 
 const app = defineApp();
 app.use(counter);

--- a/template-component/example/convex/convex.config.ts
+++ b/template-component/example/convex/convex.config.ts
@@ -1,7 +1,7 @@
 import { defineApp } from "convex/server";
-import component from "@convex-dev/counter/convex.config.js";
+import counter from "@convex-dev/counter/convex.config.js";
 
 const app = defineApp();
-app.use(component, { name: "counter" });
+app.use(counter);
 
 export default app;

--- a/template-component/example/convex/example.ts
+++ b/template-component/example/convex/example.ts
@@ -3,7 +3,7 @@ import {
   components,
   query,
   mutation,
-} from "./_generated/server.js";
+} from "./_generated/server";
 import { Client, defineCounter } from "@convex-dev/counter";
 
 const numUsers = defineCounter(components.counter, "users", 100);

--- a/template-component/package.json
+++ b/template-component/package.json
@@ -43,7 +43,7 @@
         "default": "./dist/commonjs/react.js"
       }
     },
-    "./convex.config.js": {
+    "./convex.config": {
       "import": {
         "@convex-dev/component-source": "./src/component/convex.config.ts",
         "types": "./dist/esm/component/convex.config.d.ts",

--- a/template-component/src/client/index.ts
+++ b/template-component/src/client/index.ts
@@ -6,7 +6,7 @@ import {
   GenericQueryCtx,
 } from "convex/server";
 import { GenericId } from "convex/values";
-import { api } from "../component/_generated/api.js";
+import { api } from "../component/_generated/api";
 
 export class Client<Shards extends Record<string, number>> {
   constructor(

--- a/template-component/src/component/public.ts
+++ b/template-component/src/component/public.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { mutation, query } from "./_generated/server";
 
 export const add = mutation({
   args: {

--- a/template-component/tsconfig.json
+++ b/template-component/tsconfig.json
@@ -8,8 +8,8 @@
     "lib": ["ES2021", "dom"],
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
 
     "isolatedModules": true,
     "declaration": true,


### PR DESCRIPTION
<!-- Describe your PR here. -->

- prefer `convex.confg` and drop other `.js` suffixes
- install counter w/o explicit name: this makes it easier to copy into your project and get around naming conflicts for `component`. Also name isn't needed anymore

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
