### PR TITLE
Dont print npm install warnings

### DIFF
--- a/create-convex/src/index.ts
+++ b/create-convex/src/index.ts
@@ -284,7 +284,7 @@ async function installDependencies(): Promise<void> {
     /**
      * Spawn the installation process.
      */
-    const child = spawn("npm", ["install", "--no-fund", "--no-audit"], {
+    const child = spawn("npm", ["install", "--no-fund", "--no-audit", "--loglevel=error"], {
       stdio: "inherit",
       env: {
         ...process.env,


### PR DESCRIPTION
The npm warnings are confusing and unnecessary.

## Before

![Screenshot 2024-10-17 at 22 07 00](https://github.com/user-attachments/assets/c938f5dd-1a2d-45d1-b6f4-ef29df3137dc)

## After

![Screenshot 2024-10-17 at 22 09 58](https://github.com/user-attachments/assets/0f77e0b4-ffba-4735-9db1-a44225d8c436)


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
