### PR TITLE
[template] rename Counter -> ShardedCounter

### DIFF
--- a/template-component/README.md
+++ b/template-component/README.md
@@ -4,8 +4,9 @@ This is a Convex component, ready to be published on npm.
 
 To create your own component:
 
-1. Find and replace "Counter" to your component's Name.
-1. Find and replace "counter" to your component's name everywhere but LICENSE.
+1. Find and replace "@convex-dev/sharded-counter" with your npm package's name.
+1. Find and replace "get-convex/sharded-counter" to your component's repo.
+1. Find and replace "ShardedCounter", "shardedCounter", "sharded-counter", "sharded_counter", "sharded counter", and "Sharded Counter" to your component's name.
 1. Write code in src/component for your component.
 1. Write code in src/client for your thick client.
 1. Write example usage in example/convex/example.ts.
@@ -117,9 +118,9 @@ stub directories with special pre- and post-pack scripts.
 
 ---
 
-# Convex Counter Component
+# Convex Sharded Counter Component
 
-[![npm version](https://badge.fury.io/js/@convex-dev%2Fcounter.svg)](https://badge.fury.io/js/@convex-dev%2Fcounter)
+[![npm version](https://badge.fury.io/js/@convex-dev%2Fsharded-counter.svg)](https://badge.fury.io/js/@convex-dev%2Fsharded-counter)
 
 <!-- START: Include on https://convex.dev/components -->
 
@@ -127,7 +128,7 @@ stub directories with special pre- and post-pack scripts.
 - [ ] Why should you use this component?
 - [ ] Links to Stack / other resources?
 
-Found a bug? Feature request? [File it here](https://github.com/get-convex/counter/issues).
+Found a bug? Feature request? [File it here](https://github.com/get-convex/sharded-counter/issues).
 
 ## Pre-requisite: Convex
 
@@ -142,7 +143,7 @@ Run `npm create convex` or follow any of the [quickstarts](https://docs.convex.d
 Install the component package:
 
 ```ts
-npm install @convex-dev/counter
+npm install @convex-dev/sharded-counter
 ```
 
 Create a `convex.config.ts` file in your app's `convex/` folder and install the component by calling `use`:
@@ -150,10 +151,10 @@ Create a `convex.config.ts` file in your app's `convex/` folder and install the 
 ```ts
 // convex/convex.config.ts
 import { defineApp } from "convex/server";
-import counter from "@convex-dev/counter/convex.config";
+import shardedCounter from "@convex-dev/sharded-counter/convex.config";
 
 const app = defineApp();
-app.use(counter);
+app.use(shardedCounter);
 
 export default app;
 ```
@@ -162,7 +163,7 @@ export default app;
 
 ```ts
 import { components } from "./_generated/api";
-import { Counter } from "@convex-dev/counter";
+import { ShardedCounter } from "@convex-dev/sharded-counter";
 
 const counter = new Counter(components.counter, {
   ...options,

--- a/template-component/example/convex/_generated/api.d.ts
+++ b/template-component/example/convex/_generated/api.d.ts
@@ -38,7 +38,7 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  counter: {
+  shardedCounter: {
     lib: {
       add: FunctionReference<
         "mutation",

--- a/template-component/example/convex/convex.config.ts
+++ b/template-component/example/convex/convex.config.ts
@@ -1,7 +1,7 @@
 import { defineApp } from "convex/server";
-import counter from "@convex-dev/counter/convex.config";
+import shardedCounter from "@convex-dev/sharded-counter/convex.config";
 
 const app = defineApp();
-app.use(counter);
+app.use(shardedCounter);
 
 export default app;

--- a/template-component/example/convex/example.ts
+++ b/template-component/example/convex/example.ts
@@ -1,11 +1,11 @@
 import { internalMutation, query, mutation } from "./_generated/server";
 import { components } from "./_generated/api";
-import { Counter } from "@convex-dev/counter";
+import { ShardedCounter } from "@convex-dev/sharded-counter";
 
-const counter = new Counter(components.counter, {
+const shardedCounter = new ShardedCounter(components.shardedCounter, {
   shards: { beans: 10, users: 100 },
 });
-const numUsers = counter.for("users");
+const numUsers = shardedCounter.for("users");
 
 export const addOne = mutation({
   args: {},
@@ -24,9 +24,9 @@ export const getCount = query({
 export const usingClient = internalMutation({
   args: {},
   handler: async (ctx, _args) => {
-    await counter.add(ctx, "accomplishments");
-    await counter.add(ctx, "beans", 2);
-    const count = await counter.count(ctx, "beans");
+    await shardedCounter.add(ctx, "accomplishments");
+    await shardedCounter.add(ctx, "beans", 2);
+    const count = await shardedCounter.count(ctx, "beans");
     return count;
   },
 });
@@ -44,16 +44,16 @@ export const usingFunctions = internalMutation({
 export const directCall = internalMutation({
   args: {},
   handler: async (ctx, _args) => {
-    await ctx.runMutation(components.counter.lib.add, {
+    await ctx.runMutation(components.shardedCounter.lib.add, {
       name: "pennies",
       count: 250,
     });
-    await ctx.runMutation(components.counter.lib.add, {
+    await ctx.runMutation(components.shardedCounter.lib.add, {
       name: "beans",
       count: 3,
       shards: 100,
     });
-    const count = await ctx.runQuery(components.counter.lib.count, {
+    const count = await ctx.runQuery(components.shardedCounter.lib.count, {
       name: "beans",
     });
     return count;
@@ -61,4 +61,4 @@ export const directCall = internalMutation({
 });
 
 // Direct re-export of component's API.
-export const { add, count } = counter.api();
+export const { add, count } = shardedCounter.api();

--- a/template-component/example/index.html
+++ b/template-component/example/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Counter Component Example</title>
+    <title>Sharded Counter Component Example</title>
   </head>
   <body>
     <div id="root"></div>

--- a/template-component/example/package-lock.json
+++ b/template-component/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "uses-component",
       "version": "0.0.0",
       "dependencies": {
-        "@convex-dev/counter": "file:..",
+        "@convex-dev/sharded-counter": "file:..",
         "convex": "file:../node_modules/convex",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -29,7 +29,7 @@
       }
     },
     "..": {
-      "name": "@convex-dev/counter",
+      "name": "@convex-dev/sharded-counter",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -476,7 +476,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@convex-dev/counter": {
+    "node_modules/@convex-dev/sharded-counter": {
       "resolved": "..",
       "link": true
     },
@@ -3416,7 +3416,7 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@convex-dev/counter": {
+    "@convex-dev/sharded-counter": {
       "version": "file:..",
       "requires": {
         "@eslint/js": "^9.9.1",

--- a/template-component/example/package.json
+++ b/template-component/example/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc -p convex && eslint convex"
   },
   "dependencies": {
-    "@convex-dev/counter": "file:..",
+    "@convex-dev/sharded-counter": "file:..",
     "convex": "file:../node_modules/convex",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/template-component/example/src/App.tsx
+++ b/template-component/example/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
 
   return (
     <>
-      <h1>Convex Counter Component Example</h1>
+      <h1>Convex Sharded Counter Component Example</h1>
       <div className="card">
         <button onClick={() => addOne()}>count is {count}</button>
         <p>

--- a/template-component/package.json
+++ b/template-component/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@convex-dev/counter",
-  "description": "A counter component for Convex.",
-  "repository": "github:get-convex/counter",
-  "homepage": "https://github.com/get-convex/counter#readme",
+  "name": "@convex-dev/sharded-counter",
+  "description": "A sharded counter component for Convex.",
+  "repository": "github:get-convex/sharded-counter",
+  "homepage": "https://github.com/get-convex/sharded-counter#readme",
   "bugs": {
     "email": "support@convex.dev",
-    "url": "https://github.com/get-convex/counter/issues"
+    "url": "https://github.com/get-convex/sharded-counter/issues"
   },
   "version": "0.1.0",
   "license": "Apache-2.0",

--- a/template-component/src/client/index.ts
+++ b/template-component/src/client/index.ts
@@ -10,7 +10,7 @@ import {
 import { GenericId, v } from "convex/values";
 import { api } from "../component/_generated/api";
 
-export class Counter<Shards extends Record<string, number>> {
+export class ShardedCounter<Shards extends Record<string, number>> {
   constructor(
     public component: UseApi<typeof api>,
     public options?: { shards?: Shards; defaultShards?: number }
@@ -49,7 +49,7 @@ export class Counter<Shards extends Record<string, number>> {
    * For easy re-exporting.
    * Apps can do
    * ```ts
-   * export const { add, count } = counter.api();
+   * export const { add, count } = shardedCounter.api();
    * ```
    */
   api() {

--- a/template-component/src/component/convex.config.ts
+++ b/template-component/src/component/convex.config.ts
@@ -1,3 +1,3 @@
 import { defineComponent } from "convex/server";
 
-export default defineComponent("counter");
+export default defineComponent("shardedCounter");

--- a/template-component/src/component/lib.test.ts
+++ b/template-component/src/component/lib.test.ts
@@ -7,7 +7,7 @@ import { api } from "./_generated/api.js";
 
 const modules = import.meta.glob("./**/*.*s");
 
-describe("counter", () => {
+describe("sharded-counter", () => {
   test("add and subtract", async () => {
     const t = convexTest(schema, modules);
     await t.mutation(api.lib.add, { name: "beans", count: 10 });


### PR DESCRIPTION
<!-- Describe your PR here. -->

for the component template, make the component name be two words. this is useful because it allows us to distinguish the various usages of `counter`, which is ambiguously camelCase, kebab-case, or snake_case. 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
