### PR TITLE
Add convex_rules.mdc to the .cursor/rules directory of the new project

### DIFF
--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-convex",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Convex, Inc. <team@convex.dev>",


### PR DESCRIPTION
This happens as a step in the `npm create convex` script and pulls the latest cursor rules from the convex-evals repo.

I think there's little to no risk of this breaking existing things (it's in a decently aggressive try / catch).

I took the code for finding the right release from the `convex` CLI where we find the right local backend binary (this is simpler though).

I tested this out manually with a few different templates + with creating an error myself and making sure it didn't block the template creation.
