### PR TITLE
fix OpaqueIds in component template

### DIFF
--- a/template-component/src/client/index.ts
+++ b/template-component/src/client/index.ts
@@ -79,7 +79,7 @@ type RunMutationCtx = {
   runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
 };
 
-export type OpaqueIds<T> = T extends GenericId<infer _T> | string
+export type OpaqueIds<T> = T extends GenericId<infer _T>
   ? string
   : T extends (infer U)[]
     ? OpaqueIds<U>[]


### PR DESCRIPTION
<!-- Describe your PR here. -->

there's a bug in `OpaqueIds` which causes it to turn all string literals in component args and return values into just "string".

this PR fixes the template. it would be great to put this library in a common place (maybe in the convex package) so it can be updated for all components. I think right now we have to go through each component and fix them individually.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
