### PR TITLE
Make build commands clearer

### DIFF
--- a/create-convex/README.md
+++ b/create-convex/README.md
@@ -48,4 +48,4 @@ npm create convex@latest my-app -- -t 'thomasballinger/convex-clerk-users-table#
 
 # Developing
 
-To work on this repo, make changes then `bun dev` which will output to `./dist` then `bun run dev:run` to run it with bun or `X run dev:run` where X is your package manager of choice.
+To work on this repo, make changes then `bun build` which will output to `./dist` then `bun run dev` to run it with bun or `X run dev:run` where X is your package manager of choice.

--- a/create-convex/README.md
+++ b/create-convex/README.md
@@ -48,4 +48,4 @@ npm create convex@latest my-app -- -t 'thomasballinger/convex-clerk-users-table#
 
 # Developing
 
-To work on this repo, make changes then `bun build` which will output to `./dist` then `bun run dev` to run it with bun or `X run dev:run` where X is your package manager of choice.
+To work on this repo, make changes then `bun build` which will output to `./dist` then `bun run start` to run it with bun or `X run build` where X is your package manager of choice.

--- a/create-convex/package-lock.json
+++ b/create-convex/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-convex",
-  "version": "0.0.23",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-convex",
-      "version": "0.0.23",
+      "version": "0.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "degit": "^2.8.4"

--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-convex",
-  "version": "0.0.23",
+  "version": "0.0.25",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Convex, Inc. <team@convex.dev>",

--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -20,10 +20,10 @@
   ],
   "scripts": {
     "build": "unbuild --stub",
+    "start": "node ./dist/index.mjs",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm i && npm run build",
-    "lint": "echo ESLint is not configured",
-    "dev": "node ./dist/index.mjs"
+    "lint": "echo ESLint is not configured"
   },
   "engines": {
     "node": "^18.0.0 || >=20.0.0"

--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -19,12 +19,11 @@
     "dist"
   ],
   "scripts": {
-    "dev": "unbuild --stub",
-    "build": "unbuild",
+    "build": "unbuild --stub",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm i && npm run build",
     "lint": "echo ESLint is not configured",
-    "dev:run": "node ./dist/index.mjs"
+    "dev": "node ./dist/index.mjs"
   },
   "engines": {
     "node": "^18.0.0 || >=20.0.0"

--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -22,7 +22,7 @@
     "build": "unbuild --stub",
     "start": "node ./dist/index.mjs",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm i && npm run build",
+    "prepublishOnly": "npm i && npm run typecheck && npm run build",
     "lint": "echo ESLint is not configured"
   },
   "engines": {


### PR DESCRIPTION
`build` -> removed because it is the wrong command. It doesn't build properly
`dev` -> `build` because it is the command that builds
`build` -> `start` because it is the command that starts the tool
