### PR TITLE
[tanstack-start-clerk] Fix build command

### DIFF
--- a/template-tanstack-start-clerk/package.json
+++ b/template-tanstack-start-clerk/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently -r npm:dev:web npm:dev:db",
     "dev:web": "vinxi dev",
     "dev:db": "npx convex dev",
-    "build": "vinxi build 2>/dev/null & true 'Ignore vinxi build warnings until tanstack start can run without them (need updated guide)'",
+    "build": "vinxi build 2>/dev/null && true 'Ignore vinxi build warnings until tanstack start can run without them (need updated guide)'",
     "start": "vinxi start",
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",
     "format": "prettier --write '**/*' --ignore-unknown"

--- a/template-tanstack-start-clerk/package.json
+++ b/template-tanstack-start-clerk/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently -r npm:dev:web npm:dev:db",
     "dev:web": "vinxi dev",
     "dev:db": "npx convex dev",
-    "build": "vinxi build 2>/dev/null && true 'Ignore vinxi build warnings until tanstack start can run without them (need updated guide)'",
+    "build": "vinxi build 2>/dev/null || true 'Ignore vinxi build warnings until tanstack start can run without them (need updated guide)'",
     "start": "vinxi start",
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",
     "format": "prettier --write '**/*' --ignore-unknown"


### PR DESCRIPTION
Makes Netlify and Vercel deployments possible.

The build command before this change was running `vinxi build` in the background. Deployments on Vercel and Netlify did not wait for it to finish. As a result, deployments did not include any built code, only some static files. You can see in Vercel  dashboards that the "Deployment" stage starts (and even finishes), but the "Build" stage is still in progress. In Netlify you can see the following lines in logs:

```
The build completed successfully, but the following processes were still running:
 ​
    - node /opt/build/repo/node_modules/.bin/vinxi build
    - /opt/build/repo/node_modules/vinxi/node_modules/@esbuild/linux-x64/bin/esbuild --service=0.20.2 --ping
    - /opt/buildhome/.nvm/versions/node/v22.15.1/bin/node /opt/build/repo/node_modules/vinxi/bin/cli.mjs build --router=client
    - /opt/build/repo/node_modules/vinxi/node_modules/@esbuild/linux-x64/bin/esbuild --service=0.20.2 --ping
 
These processes have been terminated. In case this creates a problem for your build, refer to this article for details about why this process termination happens and how to fix it.
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
