### PR TITLE
Remove template-publish command from the Justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,19 +17,3 @@ install *ARGS:
 commit message:
     git add template-*
     git commit -m "$1"
-
-# Publish the template to its own repo
-[no-cd]
-[no-exit-message]
-template-publish force:
-    @echo Publishing $(echo "{{invocation_directory()}}" | sed "s|^{{justfile_directory()}}/||")...
-    @if [ "$1" = "true" ]; then \
-        answer="y"; \
-    else \
-        read -p "Do you want to immediately publish this version of the template? [Y/n] " answer; \
-    fi; \
-    if [ "$answer" = "y" ] || [ "$answer" = "Y" ] || [ "$answer" = "" ]; then \
-        git push -f https://github.com/get-convex/$(echo "{{invocation_directory()}}" | sed "s|^{{justfile_directory()}}/||") HEAD:main; \
-    else \
-        echo "Not publishing."; exit 1; \
-    fi


### PR DESCRIPTION
Now that we don’t use submodules, I think this is not needed anymore.