### PR TITLE
update tanstack-start-clerk template to conform with updated createClerkHandler

### DIFF
--- a/template-tanstack-start-clerk/src/server.ts
+++ b/template-tanstack-start-clerk/src/server.ts
@@ -1,12 +1,18 @@
 import {
   createStartHandler,
   defaultStreamHandler,
+  defineHandlerCallback,
 } from '@tanstack/react-start/server'
 import { createRouter } from './router'
 import { createClerkHandler } from '@clerk/tanstack-react-start/server'
 
-export default createClerkHandler(
+const handlerFactory = createClerkHandler(
   createStartHandler({
     createRouter,
   }),
-)(defaultStreamHandler)
+)
+
+export default defineHandlerCallback(async (event) => {
+  const startHandler = await handlerFactory(defaultStreamHandler)
+  return startHandler(event)
+})


### PR DESCRIPTION
<!-- Describe your PR here. -->
`createClerkHandler` is now async so updating the template to match the [recommended way of consuming it](https://clerk.com/docs/quickstarts/tanstack-react-start#add-create-clerk-handler).

closes #59

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
