### PR TITLE
Remove --report-unused-disable-directives from nextjs-lucia-shadcn

### DIFF
--- a/template-nextjs-lucia-shadcn/package.json
+++ b/template-nextjs-lucia-shadcn/package.json
@@ -9,7 +9,7 @@
     "predev": "convex dev --until-success && convex dashboard",
     "build": "next build",
     "start": "next start",
-    "lint": "tsc && eslint convex --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && next lint --report-unused-disable-directives error --max-warnings 0"
+    "lint": "tsc && eslint convex --ext ts,tsx --max-warnings 0 && next lint --max-warnings 0"
   },
   "dependencies": {
     "@convex-dev/convex-lucia-auth": "^0.0.5",


### PR DESCRIPTION
Fixes the CI. This template is deprecated so it’s not worth investigating more
