### PR TITLE
Only run CI for projects that have been changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
                 project_changed="true"
               fi
             fi
+
+            # Special case: if workflow changed, also build all projects
+            workflow_changed=$(echo "$CHANGES" | jq -r '.workflow')
+            if [[ "$workflow_changed" == "true" ]]; then
+              project_changed="true"
+            fi
             
             if [[ "$project_changed" == "true" ]]; then
               if [[ "$project" == "template-astro" ]]; then


### PR DESCRIPTION
This will allow us to enable Renovate with less worrying about running the CI for every project every time.