### PR TITLE
add component template self-dependency to dev deps

### DIFF
--- a/template-component/package.json
+++ b/template-component/package.json
@@ -67,6 +67,7 @@
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "9.37.0",
+    "@example/sharded-counter": ".",
     "@types/node": "^20.14.8",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
Adds a self dependency to package.json so the example can resolve component imports.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
