### PR TITLE
Fix typo: github.com:workos → github.com/workos

### DIFF
--- a/template-react-vite-authkit/package.json
+++ b/template-react-vite-authkit/package.json
@@ -4,13 +4,13 @@
   "version": "0.0.0",
   "type": "module",
   "license": "MIT",
-  "homepage": "https://github.com:workos/template-convex-react-vite-authkit/#readme",
+  "homepage": "https://github.com/workos/template-convex-react-vite-authkit/#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com:workos/template-convex-react-vite-authkit.git"
+    "url": "git+https://github.com/workos/template-convex-react-vite-authkit.git"
   },
   "bugs": {
-    "url": "https://github.com:workos/template-convex-react-vite-authkit/issues"
+    "url": "https://github.com/workos/template-convex-react-vite-authkit/issues"
   },
   "scripts": {
     "dev": "npm-run-all --parallel dev:frontend dev:backend",


### PR DESCRIPTION
@thomasballinger I see that `config.ts` in the CLI includes both `github.com:workos` and `github.com/workos` for template-convex-reacet-vite-authkit, I assume that the version with `:` is a typo we should fix?

https://github.com/get-convex/convex-backend/blob/4d20ac6bfc812b011cbb9dcb41fb8ae47a2605a1/npm-packages/convex/src/cli/lib/config.ts#L1131