### PR TITLE
Revert "TanStack Start templates: change default dev port"

### DIFF
--- a/template-tanstack-start-authkit/.env.local.example
+++ b/template-tanstack-start-authkit/.env.local.example
@@ -2,7 +2,7 @@
 WORKOS_CLIENT_ID=client_your_client_id_here
 WORKOS_API_KEY=sk_test_your_api_key_here
 WORKOS_COOKIE_PASSWORD=your_secure_password_here_must_be_at_least_32_characters_long
-WORKOS_REDIRECT_URI=http://localhost:5173/api/auth/callback
+WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback
 
 # Convex Configuration
 VITE_CONVEX_URL=https://your-convex-deployment.convex.cloud

--- a/template-tanstack-start-authkit/README.md
+++ b/template-tanstack-start-authkit/README.md
@@ -27,7 +27,7 @@ After the initial setup (<2 minutes) you'll have a working full-stack app using:
 3. Configure WorkOS AuthKit:
    - Create a [WorkOS account](https://workos.com/)
    - Get your Client ID and API Key from the WorkOS dashboard
-   - In the WorkOS dashboard, add `http://localhost:5173/api/auth/callback` as a redirect URI
+   - In the WorkOS dashboard, add `http://localhost:3000/api/auth/callback` as a redirect URI
    - Generate a secure password for cookie encryption (minimum 32 characters)
    - Update your `.env.local` file with these values
 
@@ -58,7 +58,7 @@ After the initial setup (<2 minutes) you'll have a working full-stack app using:
 
    This starts both the Vite dev server (TanStack Start frontend) and Convex backend in parallel
 
-6. Open [http://localhost:5173](http://localhost:5173) to see your app
+6. Open [http://localhost:3000](http://localhost:3000) to see your app
 
 ## WorkOS AuthKit Setup
 

--- a/template-tanstack-start-authkit/vite.config.ts
+++ b/template-tanstack-start-authkit/vite.config.ts
@@ -10,6 +10,9 @@ dotenv.config({ path: '.env.local' });
 dotenv.config();
 
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   plugins: [
     tsConfigPaths({
       projects: ['./tsconfig.json'],

--- a/template-tanstack-start-clerk/vite.config.ts
+++ b/template-tanstack-start-clerk/vite.config.ts
@@ -4,6 +4,9 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   plugins: [
     tailwindcss(),
     tsConfigPaths({

--- a/template-tanstack-start/vite.config.ts
+++ b/template-tanstack-start/vite.config.ts
@@ -5,6 +5,9 @@ import tailwindcss from '@tailwindcss/vite'
 import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   plugins: [
     tailwindcss(),
     tsConfigPaths({


### PR DESCRIPTION
Reverts get-convex/templates#179

It looks like the default port of TanStack Start app is 3000 (the official templates change the default behavior from Vite). I was mistaken because of a bug in the Convex CLI. Reverting the change.