### PR TITLE
template-tanstack-start-authkit: move callback URL

### DIFF
--- a/template-tanstack-start-authkit/.env.local.example
+++ b/template-tanstack-start-authkit/.env.local.example
@@ -2,7 +2,7 @@
 WORKOS_CLIENT_ID=client_your_client_id_here
 WORKOS_API_KEY=sk_test_your_api_key_here
 WORKOS_COOKIE_PASSWORD=your_secure_password_here_must_be_at_least_32_characters_long
-WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback
+WORKOS_REDIRECT_URI=http://localhost:3000/callback
 
 # Convex Configuration
 VITE_CONVEX_URL=https://your-convex-deployment.convex.cloud

--- a/template-tanstack-start-authkit/README.md
+++ b/template-tanstack-start-authkit/README.md
@@ -27,7 +27,7 @@ After the initial setup (<2 minutes) you'll have a working full-stack app using:
 3. Configure WorkOS AuthKit:
    - Create a [WorkOS account](https://workos.com/)
    - Get your Client ID and API Key from the WorkOS dashboard
-   - In the WorkOS dashboard, add `http://localhost:3000/api/auth/callback` as a redirect URI
+   - In the WorkOS dashboard, add `http://localhost:3000/callback` as a redirect URI
    - Generate a secure password for cookie encryption (minimum 32 characters)
    - Update your `.env.local` file with these values
 

--- a/template-tanstack-start-authkit/src/components/ConvexClientProvider.tsx
+++ b/template-tanstack-start-authkit/src/components/ConvexClientProvider.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import { ConvexProvider, ConvexProviderWithAuth, ConvexReactClient  } from 'convex/react';
+import { ConvexProvider, ConvexProviderWithAuth, ConvexReactClient } from 'convex/react';
 import { AuthKitProvider, useAccessToken, useAuth } from '@workos/authkit-tanstack-react-start/client';
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   const [convex] = useState(() => {

--- a/template-tanstack-start-authkit/src/routeTree.gen.ts
+++ b/template-tanstack-start-authkit/src/routeTree.gen.ts
@@ -9,11 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedServerRouteImport } from './routes/_authenticated/server'
-import { Route as ApiAuthCallbackRouteImport } from './routes/api/auth/callback'
 
+const CallbackRoute = CallbackRouteImport.update({
+  id: '/callback',
+  path: '/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
@@ -28,50 +33,52 @@ const AuthenticatedServerRoute = AuthenticatedServerRouteImport.update({
   path: '/server',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-const ApiAuthCallbackRoute = ApiAuthCallbackRouteImport.update({
-  id: '/api/auth/callback',
-  path: '/api/auth/callback',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/callback': typeof CallbackRoute
   '/server': typeof AuthenticatedServerRoute
-  '/api/auth/callback': typeof ApiAuthCallbackRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/callback': typeof CallbackRoute
   '/server': typeof AuthenticatedServerRoute
-  '/api/auth/callback': typeof ApiAuthCallbackRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/callback': typeof CallbackRoute
   '/_authenticated/server': typeof AuthenticatedServerRoute
-  '/api/auth/callback': typeof ApiAuthCallbackRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/server' | '/api/auth/callback'
+  fullPaths: '/' | '/callback' | '/server'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/server' | '/api/auth/callback'
+  to: '/' | '/callback' | '/server'
   id:
     | '__root__'
     | '/'
     | '/_authenticated'
+    | '/callback'
     | '/_authenticated/server'
-    | '/api/auth/callback'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
-  ApiAuthCallbackRoute: typeof ApiAuthCallbackRoute
+  CallbackRoute: typeof CallbackRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/callback': {
+      id: '/callback'
+      path: '/callback'
+      fullPath: '/callback'
+      preLoaderRoute: typeof CallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
@@ -93,13 +100,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedServerRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
-    '/api/auth/callback': {
-      id: '/api/auth/callback'
-      path: '/api/auth/callback'
-      fullPath: '/api/auth/callback'
-      preLoaderRoute: typeof ApiAuthCallbackRouteImport
-      parentRoute: typeof rootRouteImport
-    }
   }
 }
 
@@ -118,7 +118,7 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
-  ApiAuthCallbackRoute: ApiAuthCallbackRoute,
+  CallbackRoute: CallbackRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/template-tanstack-start-authkit/src/routes/callback.tsx
+++ b/template-tanstack-start-authkit/src/routes/callback.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { handleCallbackRoute } from '@workos/authkit-tanstack-react-start';
 
-export const Route = createFileRoute('/api/auth/callback')({
+export const Route = createFileRoute('/callback')({
   server: {
     handlers: {
       GET: handleCallbackRoute,


### PR DESCRIPTION
This moves the WorkOS callback URL to be `/callback` instead of `/api/auth/callback`, making it consistent with other templates, and making it work with the auto-provision feature of the Convex CLI tool.