### PR TITLE
template-tanstack-start-authkit: fix auth config

### DIFF
--- a/template-tanstack-start-authkit/convex/auth.config.ts
+++ b/template-tanstack-start-authkit/convex/auth.config.ts
@@ -16,7 +16,6 @@ export default {
       issuer: `https://api.workos.com/user_management/${clientId}`,
       algorithm: 'RS256',
       jwks: `https://api.workos.com/sso/jwks/${clientId}`,
-      applicationID: clientId,
     },
   ],
 } satisfies AuthConfig;


### PR DESCRIPTION
This fixes a bug I had while testing the template which caused login attempts to fail. I realized when comparing this template to other templates that there was some inconsistency between the templates, and `template-tanstack-start-authkit` was the only one with an extra `applicationID`.