### PR TITLE
Add --with-vercel-json flag

### DIFF
--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-convex",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Convex, Inc. <team@convex.dev>",

--- a/create-convex/src/index.ts
+++ b/create-convex/src/index.ts
@@ -16,6 +16,7 @@ const argv = minimist<{
   "dry-run"?: string;
   verbose?: boolean;
   component?: boolean;
+  "with-vercel-json"?: boolean;
 }>(process.argv.slice(2), { string: ["_"] });
 const cwd = process.cwd();
 
@@ -91,6 +92,7 @@ async function init() {
   const argTemplate = argv.template || argv.t;
   const verbose = !!argv.verbose;
   const component = !!argv.component;
+  const withVercelJson = !!argv["with-vercel-json"];
 
   let targetDir = argTargetDir || defaultTargetDir;
   const getProjectName = () =>
@@ -266,6 +268,18 @@ async function init() {
     fs.writeFileSync(
       path.join(root, "package.json"),
       JSON.stringify(pkg, null, 2) + "\n",
+    );
+  }
+
+  if (withVercelJson) {
+    const vercelConfig = {
+      $schema: "https://openapi.vercel.sh/vercel.json",
+      buildCommand: "npx convex deploy --cmd 'npm run build'",
+    };
+
+    fs.writeFileSync(
+      path.join(root, "vercel.json"),
+      JSON.stringify(vercelConfig, null, 2) + "\n",
     );
   }
 


### PR DESCRIPTION
Adds a --with-vercel-json flag that automatically create a vercel.json that sets up the build directory. To be used for the Vercel marketplace integration docs

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
