### PR TITLE
add yet another entrypoint?

### DIFF
--- a/template-component/package.json
+++ b/template-component/package.json
@@ -52,6 +52,9 @@
     "./_generated/component.js": {
       "types": "./dist/component/_generated/component.d.ts"
     },
+    "./_generated/component": {
+      "types": "./dist/component/_generated/component.d.ts"
+    },
     "./convex.config.js": {
       "types": "./dist/component/convex.config.d.ts",
       "default": "./dist/component/convex.config.js"


### PR DESCRIPTION
<!-- Describe your PR here. -->

Are we going overboard on NodeNext syntax? 
- NodeNext shouldn't be used to bundle Convex code.
- Component implementation code isn't accessible outside of Convex (currently). So why do we need the ComponentApi type to conform to a syntax that most people don't use / looks funny?

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
