### PR TITLE
more lax tsconfig

### DIFF
--- a/template-component/example/tsconfig.json
+++ b/template-component/example/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/template-component/tsconfig.build.json
+++ b/template-component/tsconfig.build.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "./src/test.ts"],
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "Bundler"
-  }
+  "exclude": ["src/**/*.test.*", "./src/test.ts"]
 }

--- a/template-component/tsconfig.json
+++ b/template-component/tsconfig.json
@@ -10,10 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "noErrorTruncation": true,
-    // We enforce stricter module resolution for Node16 compatibility
-    // But when building we use Bundler & ESNext for ESM
-    "module": "Node16",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
 
     "composite": true,
     "isolatedModules": true,


### PR DESCRIPTION
<!-- Describe your PR here. -->

I'm not sure we benefit much / at all from the NodeNext constraint. I don't think anyone should be bundling their convex code with NodeNext, so the only constraints here are exports that might be used in other environments. 
It doesn't help with Expo / Metro bundling.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
