### PR TITLE
Fix issues with tanstack-start-authkit

### DIFF
--- a/template-tanstack-start-authkit/package.json
+++ b/template-tanstack-start-authkit/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-router": "^1.132.41",
     "@tanstack/react-router-ssr-query": "^1.132.43",
     "@tanstack/react-start": "^1.132.43",
-    "@workos/authkit-tanstack-react-start": "0.1.0",
+    "@workos/authkit-tanstack-react-start": "0.4.1",
     "convex": "^1.31.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1"

--- a/template-tanstack-start-authkit/src/router.tsx
+++ b/template-tanstack-start-authkit/src/router.tsx
@@ -2,7 +2,7 @@ import { createRouter } from '@tanstack/react-router';
 import { ConvexQueryClient } from '@convex-dev/react-query';
 import { QueryClient } from '@tanstack/react-query';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
-import { ConvexProvider, ConvexProviderWithAuth, ConvexReactClient } from 'convex/react';
+import { ConvexProviderWithAuth, ConvexReactClient } from 'convex/react';
 import { AuthKitProvider, useAccessToken, useAuth } from '@workos/authkit-tanstack-react-start/client';
 import { useCallback, useMemo } from 'react';
 import { routeTree } from './routeTree.gen';
@@ -34,7 +34,7 @@ export function getRouter() {
     defaultErrorComponent: (err) => <p>{err.error.stack}</p>,
     defaultNotFoundComponent: () => <p>not found</p>,
     context: { queryClient, convexClient: convex, convexQueryClient },
-    Wrap: ({ children }) => (
+    InnerWrap: ({ children }) => (
       <AuthKitProvider>
         <ConvexProviderWithAuth client={convexQueryClient.convexClient} useAuth={useAuthFromWorkOS}>
           {children}


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixed issues mentioned in #204 
1. For `Warning: useRouter must be used inside a <RouterProvider> component`: changed `Wrap` to `InnerWrap` In router.tsx
2. Redirect loops when trying to sign out, fixed in @workos/authkit-tanstack-react-start 0.2.0. Updated to latest version.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
