### PR TITLE
Add prepublishOnly script to check npm login status

### DIFF
--- a/template-component/package.json
+++ b/template-component/package.json
@@ -30,6 +30,7 @@
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text",
     "preversion": "npm ci && npm run build:clean && run-p test lint typecheck",
+    "prepublishOnly": "npm whoami || npm login",
     "alpha": "npm version prerelease --preid alpha && npm publish --tag alpha && git push --follow-tags",
     "release": "npm version patch && npm publish && git push --follow-tags",
     "version": "vim -c 'normal o' -c 'normal o## '$npm_package_version CHANGELOG.md && prettier -w CHANGELOG.md && git add CHANGELOG.md"


### PR DESCRIPTION
Ensures user is logged in to npm before publishing by running
`npm whoami || npm login` in the prepublishOnly lifecycle hook.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>