### PR TITLE
Refactor imports in router and update comments in root route for clarity

### DIFF
--- a/template-tanstack-start-authkit/src/router.tsx
+++ b/template-tanstack-start-authkit/src/router.tsx
@@ -2,7 +2,7 @@ import { createRouter } from '@tanstack/react-router';
 import { ConvexQueryClient } from '@convex-dev/react-query';
 import { QueryClient } from '@tanstack/react-query';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
-import { ConvexProvider, ConvexProviderWithAuth, ConvexReactClient } from 'convex/react';
+import { ConvexProviderWithAuth, ConvexReactClient } from 'convex/react';
 import { AuthKitProvider, useAccessToken, useAuth } from '@workos/authkit-tanstack-react-start/client';
 import { useCallback, useMemo } from 'react';
 import { routeTree } from './routeTree.gen';

--- a/template-tanstack-start-authkit/src/routes/__root.tsx
+++ b/template-tanstack-start-authkit/src/routes/__root.tsx
@@ -46,7 +46,7 @@ export const Route = createRootRouteWithContext<{
     const { userId, token } = await fetchWorkosAuth();
 
     // During SSR only (the only time serverHttpClient exists),
-    // set the Clerk auth token to make HTTP queries with.
+    // set the WorkOS auth token to make HTTP queries with.
     if (token) {
       ctx.context.convexQueryClient.serverHttpClient?.setAuth(token);
     }


### PR DESCRIPTION
- Removed unused import of ConvexProvider from router.tsx.
- Updated comment in __root.tsx to correctly reference WorkOS auth token instead of Clerk.