### PR TITLE
Fix TanStack Start AuthKit template provider placement

### DIFF
--- a/template-tanstack-start-authkit/src/router.tsx
+++ b/template-tanstack-start-authkit/src/router.tsx
@@ -34,7 +34,9 @@ export function getRouter() {
     defaultErrorComponent: (err) => <p>{err.error.stack}</p>,
     defaultNotFoundComponent: () => <p>not found</p>,
     context: { queryClient, convexClient: convex, convexQueryClient },
-    Wrap: ({ children }) => (
+    // AuthKitProvider uses TanStack Router hooks internally, so it must
+    // render inside router context. InnerWrap renders inside the router.
+    InnerWrap: ({ children }) => (
       <AuthKitProvider>
         <ConvexProviderWithAuth client={convexQueryClient.convexClient} useAuth={useAuthFromWorkOS}>
           {children}


### PR DESCRIPTION
## Problem
The `template-tanstack-start-authkit` template was using `Wrap` to render `AuthKitProvider` around the router. `AuthKitProvider` internally uses TanStack Router hooks (`useNavigate`), which require router context.

`Wrap` renders **outside** the router context, causing the runtime warning:
```
Warning: useRouter must be used inside a <RouterProvider> component!
```

## Fix
Replace `Wrap` with `InnerWrap`, which renders **inside** the router context and provides the necessary context for `AuthKitProvider`'s internal hooks.

## Validation
- `tsc --noEmit` passes
- `npm run build` passes
- `npm run lint` passes