### PR TITLE
fix tanstack workos sign-in/sign-up routes

### DIFF
--- a/template-tanstack-start-authkit/src/routeTree.gen.ts
+++ b/template-tanstack-start-authkit/src/routeTree.gen.ts
@@ -9,11 +9,23 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignUpRouteImport } from './routes/sign-up'
+import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedAuthenticatedRouteImport } from './routes/_authenticated/authenticated'
 
+const SignUpRoute = SignUpRouteImport.update({
+  id: '/sign-up',
+  path: '/sign-up',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SignInRoute = SignInRouteImport.update({
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CallbackRoute = CallbackRouteImport.update({
   id: '/callback',
   path: '/callback',
@@ -38,11 +50,15 @@ const AuthenticatedAuthenticatedRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/callback': typeof CallbackRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
   '/authenticated': typeof AuthenticatedAuthenticatedRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/callback': typeof CallbackRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
   '/authenticated': typeof AuthenticatedAuthenticatedRoute
 }
 export interface FileRoutesById {
@@ -50,18 +66,22 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/callback': typeof CallbackRoute
+  '/sign-in': typeof SignInRoute
+  '/sign-up': typeof SignUpRoute
   '/_authenticated/authenticated': typeof AuthenticatedAuthenticatedRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/callback' | '/authenticated'
+  fullPaths: '/' | '/callback' | '/sign-in' | '/sign-up' | '/authenticated'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/callback' | '/authenticated'
+  to: '/' | '/callback' | '/sign-in' | '/sign-up' | '/authenticated'
   id:
     | '__root__'
     | '/'
     | '/_authenticated'
     | '/callback'
+    | '/sign-in'
+    | '/sign-up'
     | '/_authenticated/authenticated'
   fileRoutesById: FileRoutesById
 }
@@ -69,10 +89,26 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   CallbackRoute: typeof CallbackRoute
+  SignInRoute: typeof SignInRoute
+  SignUpRoute: typeof SignUpRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sign-up': {
+      id: '/sign-up'
+      path: '/sign-up'
+      fullPath: '/sign-up'
+      preLoaderRoute: typeof SignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/callback': {
       id: '/callback'
       path: '/callback'
@@ -120,6 +156,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   CallbackRoute: CallbackRoute,
+  SignInRoute: SignInRoute,
+  SignUpRoute: SignUpRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/template-tanstack-start-authkit/src/routes/__root.tsx
+++ b/template-tanstack-start-authkit/src/routes/__root.tsx
@@ -1,21 +1,10 @@
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
-import { createServerFn } from '@tanstack/react-start';
 import { getAuth } from '@workos/authkit-tanstack-react-start';
 import appCssUrl from '../app.css?url';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { ConvexReactClient } from 'convex/react';
 import type { ConvexQueryClient } from '@convex-dev/react-query';
-
-const fetchWorkosAuth = createServerFn({ method: 'GET' }).handler(async () => {
-  const auth = await getAuth();
-  const { user } = auth;
-
-  return {
-    userId: user?.id ?? null,
-    token: user ? auth.accessToken : null,
-  };
-});
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -43,15 +32,15 @@ export const Route = createRootRouteWithContext<{
   component: RootComponent,
   notFoundComponent: () => <div>Not Found</div>,
   beforeLoad: async (ctx) => {
-    const { userId, token } = await fetchWorkosAuth();
+    const auth = await getAuth();
 
     // During SSR only (the only time serverHttpClient exists),
     // set the WorkOS auth token to make HTTP queries with.
-    if (token) {
-      ctx.context.convexQueryClient.serverHttpClient?.setAuth(token);
+    if (auth.user) {
+      ctx.context.convexQueryClient.serverHttpClient?.setAuth(auth.accessToken);
     }
 
-    return { userId, token };
+    return { user: auth.user };
   },
 });
 

--- a/template-tanstack-start-authkit/src/routes/_authenticated.tsx
+++ b/template-tanstack-start-authkit/src/routes/_authenticated.tsx
@@ -1,13 +1,13 @@
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
-import { getAuth, getSignInUrl } from '@workos/authkit-tanstack-react-start';
+import { getAuth } from '@workos/authkit-tanstack-react-start';
 
 export const Route = createFileRoute('/_authenticated')({
   loader: async ({ location }) => {
     const { user } = await getAuth();
     if (!user) {
-      const path = location.pathname;
-      const href = await getSignInUrl({ data: { returnPathname: path } });
-      throw redirect({ href });
+      throw redirect({
+        href: `/sign-in?returnPathname=${encodeURIComponent(location.pathname)}`,
+      });
     }
   },
   component: () => <Outlet />,

--- a/template-tanstack-start-authkit/src/routes/index.tsx
+++ b/template-tanstack-start-authkit/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { Link, createFileRoute } from '@tanstack/react-router';
 import { Authenticated, Unauthenticated, useMutation } from 'convex/react';
 import { useAuth } from '@workos/authkit-tanstack-react-start/client';
-import { getAuth, getSignInUrl, getSignUpUrl } from '@workos/authkit-tanstack-react-start';
+import { getAuth } from '@workos/authkit-tanstack-react-start';
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { api } from '../../convex/_generated/api';
@@ -11,19 +11,16 @@ export const Route = createFileRoute('/')({
   component: Home,
   loader: async () => {
     const { user } = await getAuth();
-    const signInUrl = await getSignInUrl();
-    const signUpUrl = await getSignUpUrl();
-
-    return { user, signInUrl, signUpUrl };
+    return { user };
   },
 });
 
 function Home() {
-  const { user, signInUrl, signUpUrl } = Route.useLoaderData();
-  return <HomeContent user={user} signInUrl={signInUrl} signUpUrl={signUpUrl} />;
+  const { user } = Route.useLoaderData();
+  return <HomeContent user={user} />;
 }
 
-function HomeContent({ user, signInUrl, signUpUrl }: { user: User | null; signInUrl: string; signUpUrl: string }) {
+function HomeContent({ user }: { user: User | null }) {
   return (
     <>
       <header className="sticky top-0 z-10 bg-background p-4 border-b-2 border-slate-200 dark:border-slate-800 flex flex-row justify-between items-center">
@@ -36,21 +33,21 @@ function HomeContent({ user, signInUrl, signUpUrl }: { user: User | null; signIn
           <Content />
         </Authenticated>
         <Unauthenticated>
-          <SignInForm signInUrl={signInUrl} signUpUrl={signUpUrl} />
+          <SignInForm />
         </Unauthenticated>
       </main>
     </>
   );
 }
 
-function SignInForm({ signInUrl, signUpUrl }: { signInUrl: string; signUpUrl: string }) {
+function SignInForm() {
   return (
     <div className="flex flex-col gap-8 w-96 mx-auto">
       <p>Log in to see the numbers</p>
-      <a href={signInUrl}>
+      <a href="/sign-in">
         <button className="bg-foreground text-background px-4 py-2 rounded-md">Sign in</button>
       </a>
-      <a href={signUpUrl}>
+      <a href="/sign-up">
         <button className="bg-foreground text-background px-4 py-2 rounded-md">Sign up</button>
       </a>
     </div>

--- a/template-tanstack-start-authkit/src/routes/sign-in.tsx
+++ b/template-tanstack-start-authkit/src/routes/sign-in.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { getSignInUrl } from '@workos/authkit-tanstack-react-start';
+
+export const Route = createFileRoute('/sign-in')({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const returnPathname = new URL(request.url).searchParams.get('returnPathname');
+        const url = await getSignInUrl(returnPathname ? { data: { returnPathname } } : undefined);
+        return new Response(null, {
+          status: 307,
+          headers: { Location: url },
+        });
+      },
+    },
+  },
+});

--- a/template-tanstack-start-authkit/src/routes/sign-up.tsx
+++ b/template-tanstack-start-authkit/src/routes/sign-up.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { getSignUpUrl } from '@workos/authkit-tanstack-react-start';
+
+export const Route = createFileRoute('/sign-up')({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const returnPathname = new URL(request.url).searchParams.get('returnPathname');
+        const url = await getSignUpUrl(returnPathname ? { data: { returnPathname } } : undefined);
+        return new Response(null, {
+          status: 307,
+          headers: { Location: url },
+        });
+      },
+    },
+  },
+});


### PR DESCRIPTION
<!-- Describe your PR here. -->
Split out sign-in/sign-up to routes to avoid cookie pile-up on successive loads.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
