### PR TITLE
add prepare script to component template

### DIFF
--- a/template-component/package.json
+++ b/template-component/package.json
@@ -27,6 +27,7 @@
     "test:watch": "vitest --typecheck --clearScreen false",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text",
+    "prepare": "npm run build",
     "preversion": "npm ci && npm run build:clean && npm run test && npm run lint && npm run typecheck",
     "alpha": "npm version prerelease --preid alpha && npm publish --tag alpha && git push --follow-tags",
     "release": "npm version patch && npm publish && git push --follow-tags",


### PR DESCRIPTION
Adds a `prepare` script to the component template that automatically runs the build when the package is installed or published, ensuring the package is always built before use.