### PR TITLE
Remove schedule option from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
-  schedule: ["* 0-4 * * 1-5"],
   timezone: "America/Los_Angeles",
   minimumReleaseAge: "7 days",
   ignorePaths: [

--- a/template-component/renovate.json
+++ b/template-component/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "schedule": ["* 0-4 * * 1"],
   "timezone": "America/Los_Angeles",
   "packageRules": [
     {


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#schedule: the `schedule` option only limits the hours/days when PRs can be created, so it’s not useful to have it.