### PR TITLE
Fix ~28s delayed exit in create-convex by upgrading degit to 3.6.1

### DIFF
--- a/create-convex/package-lock.json
+++ b/create-convex/package-lock.json
@@ -8,18 +8,15 @@
       "name": "create-convex",
       "version": "0.0.46",
       "license": "Apache-2.0",
-      "dependencies": {
-        "degit": "^2.8.4"
-      },
       "bin": {
         "create-convex": "index.js"
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
-        "@types/degit": "^2.8.6",
         "@types/minimist": "^1.2.5",
         "@types/prompts": "^2.4.9",
         "cross-spawn": "^7.0.6",
+        "degit": "^3.6.1",
         "kolorist": "^1.8.0",
         "minimist": "^1.2.8",
         "patch-package": "^8.0.1",
@@ -1029,13 +1026,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/degit": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@types/degit/-/degit-2.8.6.tgz",
-      "integrity": "sha512-y0M7sqzsnHB6cvAeTCBPrCQNQiZe8U4qdzf8uBVmOWYap5MMTN/gB2iEqrIqFiYcsyvP74GnGD5tgsHttielFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1716,14 +1706,16 @@
       "dev": true
     },
     "node_modules/degit": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
-      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-3.6.1.tgz",
+      "integrity": "sha512-nqWTSl9Gfz1JUzmbNOkjLgFBF1K3NCKfeSZlg7udhQCnqGvk8EPDaVvN00o9IZiMByIscx6NmXx6gUsLMcWIQg==",
+      "dev": true,
+      "license": "MIT",
       "bin": {
         "degit": "degit"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/dom-serializer": {

--- a/create-convex/package-lock.json
+++ b/create-convex/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/create-convex/package.json
+++ b/create-convex/package.json
@@ -31,14 +31,14 @@
     "prepare": "patch-package"
   },
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
-    "@types/degit": "^2.8.6",
     "@types/minimist": "^1.2.5",
     "@types/prompts": "^2.4.9",
     "cross-spawn": "^7.0.6",
+    "degit": "^3.6.1",
     "kolorist": "^1.8.0",
     "minimist": "^1.2.8",
     "patch-package": "^8.0.1",
@@ -46,8 +46,5 @@
     "prompts": "^2.4.2",
     "unbuild": "^3.6.1",
     "vitest": "^4.1.4"
-  },
-  "dependencies": {
-    "degit": "^2.8.4"
   }
 }


### PR DESCRIPTION
This updates the `degit` dependency to the latest version. It fixes a bug in `create-convex` where the command would hang for ~30 seconds after a cache miss.

I tested manually that this test works, and verified in the [Degit changelog](https://github.com/Rich-Harris/degit/blob/master/docs/CHANGELOG.md) that we don’t care about the breaking changes in 3.x (it breaks support for Node 18, which has been EOL for more than a year)

<details><summary><strong>Fable-authored PR description with more details</strong></summary>

## Problem

`npm create convex` / `bunx create-convex` would appear to hang after printing its final message ("Check out the Convex docs at: …"), then exit on its own ~28 seconds later. It only happened on runs with a degit cache miss (i.e., the first run after any commit to this repo), which made it look intermittent.

## Root cause

degit 2.8.4 downloads template tarballs from `github.com/<repo>/archive/<hash>.tar.gz`, which responds with a 302 redirect to `codeload.github.com`. Its `fetch()` reads the `Location` header and follows the redirect, but never consumes or destroys the redirect response. Because the redirect is cross-origin, the keep-alive socket to github.com is never reused — it sits referenced in Node's HTTP agent, keeping the event loop alive until GitHub's load balancer closes the idle connection (~28s).

Diagnosed from a live occurrence: `lsof` showed a single ESTABLISHED socket to github.com (not codeload) as the only remaining handle, with the main thread idle in `kevent`.

## Fix

degit was revived upstream and 3.6.1 fixes this exact bug (`response.resume()` on redirect and error responses). This PR:

- Upgrades degit 2.8.4 → 3.6.1
- Moves it to `devDependencies` so unbuild's `inlineDependencies` bundles it into `dist` like every other dependency (published package now has zero runtime dependencies; this also keeps patch-package viable for degit in the future, since patches only reach users when the code is bundled)
- Drops `@types/degit` (3.x ships its own types)
- Bumps `engines` to `node >=20` (required by degit 3.x; Node 18 is EOL, and CI already runs Node 24)

## Verification

- Cache-miss runs against real GitHub: final-message→exit delay **28.8s → 0.0s**, total run **30.7s → ~1s** (5/5 runs each)
- Full sanity run: template extracted correctly, project name applied, `--verbose` info events still print
- Behavioral audit of degit 2.8.4 → 3.6.1 (full changelog + source review of the risky items): subdir+branch refs, slashed branch refs via `CONVEX_TEMPLATE_BRANCH`, warm-cache reuse, and fast failure on nonexistent repos all verified working; commit-hash refs fail identically on 2.8.4 (pre-existing limitation, not a regression); the new git-fallback path only triggers when a tarball download fails and uses HTTPS for public repos (no prompts reachable); no template contains a `degit.json`
- `npm run typecheck` clean, all 10 tests pass

Note: degit 3.x moved its cache from `~/.degit` to the platform cache dir (`~/Library/Caches/degit` on macOS), so the first run after this upgrade re-downloads once.
</details> 

